### PR TITLE
Fixed image path in Homework 1.

### DIFF
--- a/Homeworks/hw_1/hw_1_assignment.ipynb
+++ b/Homeworks/hw_1/hw_1_assignment.ipynb
@@ -68,7 +68,7 @@
     "\n",
     "Here, we'll combine about 4 seconds of a shaky video to reveal the statement on a license plate that is not discernable in any one frame.\n",
     "\n",
-    "<img src=\"data/im2-1.png\">\n",
+    "<img src=\"Data/im2-1.png\">\n",
     "\n",
     "A tarball of the data is at: https://drive.google.com/open?id=0B4vIeCR-xYNnbXFJTTVlVnpUZkk\n",
     "\n",


### PR DESCRIPTION
The homework data tarball extracts to "Data", not "data", at least on my machine.
